### PR TITLE
Undefault tasks for C++ Debugger

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
                 "-std=c++14",
                 "${file}",
                 "-o",
-                "${fileDirname}/${fileBasenameNoExtension}.out",
+                "${fileDirname}/${fileBasenameNoExtension}.out"
             ],
             "options": {
                 "cwd": "/usr/local/bin"
@@ -21,10 +21,7 @@
             "problemMatcher": [
                 "$g++"
             ],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            }
+            "group": "build"
         },
         {
             "label": "test_atcoder_sample",
@@ -38,7 +35,8 @@
                 "${fileBasenameNoExtension}",
                 "${fileExtname}",
                 "${file}"
-            ]
+            ],
+            "problemMatcher": []
         }
     ]
 }


### PR DESCRIPTION
デバッガー起動のためにlaunch.jsonが必要なものはtasks.jsonのタスクのラベルだけだと思うので、ビルドタスクのデフォルトにする必要がないと思う。現状、command + shift + Bでビルドタスクを実行した時にデフォルトのタスクが二つ(テストとc++のデバッガー)あるせいでタスク選択のための操作が一個増えている。

command + shift + B をテスト、F5でデバッグという操作感にするだけなら、デフォルトオプションを外せばいいと思う。